### PR TITLE
CEMS-1881 Todd/dev/error reporting

### DIFF
--- a/api/App.php
+++ b/api/App.php
@@ -12,10 +12,17 @@ class App extends \Slim\App {
 
   public function __construct(ContainerInterface $diContainer=null) {
     if (getenv('APP_ENV') == 'dev') {
-      error_reporting(E_ALL);
+      $this->devMode();
     }
     parent::__construct($diContainer ?: $this->_diContainer());
     $this->loadRoutes(...$this->_routes());
+  }
+
+  private function devMode() {
+    $logFile = Logger::logDir()."/php-error.log";
+    error_reporting(E_ALL);
+    ini_set("log_errors", 1);
+    ini_set("error_log", $logFile);
   }
 
   private function _diContainer() {

--- a/api/App.php
+++ b/api/App.php
@@ -10,11 +10,15 @@ class App extends \Slim\App {
   public $routesFile = APP_ROOT.'/api/routes.php';
   public $servicesFile = APP_ROOT.'/api/services.php';
 
+  /** @var DiContainer */
+  private $_di;
+
   public function __construct(ContainerInterface $diContainer=null) {
+    $this->_di = $diContainer ?: $this->_diContainer();
     if (getenv('APP_ENV') == 'dev') {
       $this->devMode();
     }
-    parent::__construct($diContainer ?: $this->_diContainer());
+    parent::__construct($this->_di);
     $this->loadRoutes(...$this->_routes());
   }
 

--- a/api/App.php
+++ b/api/App.php
@@ -11,6 +11,9 @@ class App extends \Slim\App {
   public $servicesFile = APP_ROOT.'/api/services.php';
 
   public function __construct(ContainerInterface $diContainer=null) {
+    if (getenv('APP_ENV') == 'dev') {
+      error_reporting(E_ALL);
+    }
     parent::__construct($diContainer ?: $this->_diContainer());
     $this->loadRoutes(...$this->_routes());
   }

--- a/api/DiContainer.php
+++ b/api/DiContainer.php
@@ -5,15 +5,18 @@ namespace HomeCEU\DTS\Api;
 
 use HomeCEU\DTS\Db;
 use HomeCEU\DTS\Render\TemplateCompiler;
+use Monolog\Logger;
 use Psr\Container\ContainerInterface;
+use Slim\Container;
 
 /**
  * Class DiContainer
  * @property Db\Config dbConfig
  * @property Db\Connection dbConnection
  * @property TemplateCompiler templateCompiler
+ * @property Logger logger
  */
-class DiContainer extends \Slim\Container implements ContainerInterface {
+class DiContainer extends Container implements ContainerInterface {
   public function __construct(array $values = []) {
     if ($values == []) {
       $values = include __DIR__."/services.php";

--- a/api/DocData/Exists.php
+++ b/api/DocData/Exists.php
@@ -11,6 +11,7 @@ use HomeCEU\DTS\UseCase\DocDataVersionList;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Exception\NotFoundException;
 
 class Exists {
 
@@ -36,7 +37,7 @@ class Exists {
   public function __invoke(Request $request, Response $response, $args) {
     $versions = $this->useCase->versions($args['docType'], $args['dataKey']);
     if (count($versions) < 1) {
-      return $response->withStatus(404);
+      throw new NotFoundException($request, $response);
     }
     return $response->withStatus(200);
   }

--- a/api/DocData/GetDocDataById.php
+++ b/api/DocData/GetDocDataById.php
@@ -12,6 +12,7 @@ use HomeCEU\DTS\Repository\DocDataRepository;
 use HomeCEU\DTS\Repository\RecordNotFoundException;
 use HomeCEU\DTS\UseCase\GetDocData;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Exception\NotFoundException;
 use Slim\Http\Response;
 
 class GetDocDataById {
@@ -34,9 +35,7 @@ class GetDocDataById {
           ->withStatus(200)
           ->withJson($responseData);
     } catch (RecordNotFoundException $e) {
-      return $response->withStatus(404);
-    } catch (Exception $e) {
-      return $response->withStatus(500, __CLASS__." failure");
+      throw new NotFoundException($request, $response);
     }
   }
 }

--- a/api/DocData/GetDocDataByKey.php
+++ b/api/DocData/GetDocDataByKey.php
@@ -12,6 +12,7 @@ use HomeCEU\DTS\Repository\DocDataRepository;
 use HomeCEU\DTS\Repository\RecordNotFoundException;
 use HomeCEU\DTS\UseCase\GetDocData;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Exception\NotFoundException;
 use Slim\Http\Response;
 
 class GetDocDataByKey {
@@ -33,9 +34,7 @@ class GetDocDataByKey {
           ->withStatus(200)
           ->withJson($responseData);
     } catch (RecordNotFoundException $e) {
-      return $response->withStatus(404);
-    } catch (Exception $e) {
-      return $response->withStatus(500, __CLASS__." failure");
+      throw new NotFoundException($request, $response);
     }
   }
 }

--- a/api/DocData/ListVersions.php
+++ b/api/DocData/ListVersions.php
@@ -36,7 +36,6 @@ class ListVersions {
   }
 
   public function __invoke(Request $request, Response $response, $args) {
-    try {
       $versions = $this->useCase->versions($args['docType'], $args['dataKey']);
       $responseData = [
           'total' => count($versions),
@@ -45,8 +44,5 @@ class ListVersions {
           }, $versions)
       ];
       return $response->withJson($responseData);
-    } catch (\Exception $e) {
-      return $response->withStatus(500, __CLASS__." failure");
-    }
   }
 }

--- a/api/ErrorHandler.php
+++ b/api/ErrorHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+
+namespace HomeCEU\DTS\Api;
+
+use Exception;
+use Slim\Http\Request;
+use Slim\Http\Response;
+
+/**
+ * Class ErrorHandler
+ * @package HomeCEU\DTS\Api
+ * https://www.slimframework.com/docs/v3/handlers/error.html
+ *
+ * This is triggered whenever an exception is thrown past the route handlers
+ */
+class ErrorHandler {
+  /**
+   * @var DiContainer
+   */
+  private $di;
+
+  public function __construct(DiContainer $di) {
+    $this->di = $di;
+  }
+
+  public function __invoke(Request $r, Response $response, \Throwable $exception) {
+    $requestId = uniqid('REQ_');
+    $this->di->logger->error($exception, [
+        'Request' => [
+            $requestId,
+            $r->getMethod().' '.$r->getUri()->getPath(),
+            $r->getQueryParams()
+        ],
+    ]);
+    return $response
+        ->withStatus(500)
+        ->withHeader('Content-Type', 'text/html')
+        ->write("Something unexpected went wrong!  Please report this issue referencing {$requestId}");
+  }
+}

--- a/api/Logger.php
+++ b/api/Logger.php
@@ -1,0 +1,47 @@
+<?php
+
+
+namespace HomeCEU\DTS\Api;
+
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\StreamHandler;
+use Psr\Log\LoggerInterface;
+
+class Logger {
+  /** @var \Monolog\Logger */
+  private static $instance;
+
+  public static function instance(): LoggerInterface {
+    if (empty(self::$instance)) {
+      $logger = new \Monolog\Logger('applog');
+      $logger->pushHandler(self::monologHandler());
+      self::$instance = $logger;
+    }
+    return self::$instance;
+  }
+
+  public static function logDir() {
+    $appLogDir = getenv('APP_LOG_DIR') ?: APP_ROOT.'/log';
+    return substr($appLogDir, 0, 1) == '/'
+        ? $appLogDir
+        : APP_ROOT.'/'.$appLogDir;
+  }
+
+  protected static function monologHandler() {
+    $logFile = self::logDir().'/app.log';
+    $h = new StreamHandler($logFile, \Monolog\Logger::NOTICE);
+    $h->setFormatter(self::monologFormatter());
+    return $h;
+  }
+
+  protected static function monologFormatter(): FormatterInterface {
+    $formatter = new LineFormatter(
+        LineFormatter::SIMPLE_FORMAT,
+        LineFormatter::SIMPLE_DATE
+    );
+    $formatter->includeStacktraces(true);
+    return $formatter;
+  }
+}

--- a/api/Logger.php
+++ b/api/Logger.php
@@ -16,7 +16,8 @@ class Logger {
   public static function instance(): LoggerInterface {
     if (empty(self::$instance)) {
       $logger = new \Monolog\Logger('applog');
-      $logger->pushHandler(self::monologHandler());
+      $handler = self::monologHandler();
+      $logger->pushHandler($handler);
       self::$instance = $logger;
     }
     return self::$instance;
@@ -30,7 +31,7 @@ class Logger {
   }
 
   protected static function monologHandler() {
-    $logFile = self::logDir().'/app.log';
+    $logFile = self::logDir().'/dts.log';
     $h = new StreamHandler($logFile, \Monolog\Logger::NOTICE);
     $h->setFormatter(self::monologFormatter());
     return $h;

--- a/api/Render/HotRender.php
+++ b/api/Render/HotRender.php
@@ -12,6 +12,7 @@ use HomeCEU\DTS\UseCase\Render\HotRenderRequest;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
+use Slim\Exception\NotFoundException;
 use Slim\Http\Stream;
 
 class HotRender {
@@ -26,17 +27,17 @@ class HotRender {
   public function __invoke(Request $request, Response $response, $args) {
     try {
       $qp = $request->getQueryParams();
-      $request = HotRenderRequest::fromState([
+      $r = HotRenderRequest::fromState([
           'requestId' => $args['requestId'],
           'format' => empty($qp['format']) ? 'html' : $qp['format']
       ]);
-      $renderResponse = $this->useCase->render($request);
+      $renderResponse = $this->useCase->render($r);
       return $response
           ->withHeader('Content-Type', $renderResponse->contentType)
           ->withBody(new Stream(fopen($renderResponse->path, 'r')))
           ->withStatus(200);
     } catch (RecordNotFoundException $e) {
-      return $response->withStatus(404);
+      throw new NotFoundException($request, $response);
     }
   }
 }

--- a/api/Render/Render.php
+++ b/api/Render/Render.php
@@ -15,6 +15,7 @@ use HomeCEU\DTS\UseCase\Render\Render as RenderUseCase;
 use HomeCEU\DTS\UseCase\Render\RenderRequest;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Exception\NotFoundException;
 use Slim\Http\Stream;
 
 class Render {
@@ -55,11 +56,9 @@ class Render {
           ->withBody(new Stream(fopen($renderResponse->path, 'r')))
           ->withStatus(200);
     } catch (RecordNotFoundException $e) {
-      return $response->withStatus(404);
+      throw new NotFoundException($request, $response);
     } catch (InvalidRenderRequestException $e) {
       return $response->withStatus(400, "Invalid Render Request, not enough information");
-    } catch (\Exception $e) {
-      return $response->withStatus(500, __CLASS__." failure");
     }
   }
 

--- a/api/Template/GetTemplate.php
+++ b/api/Template/GetTemplate.php
@@ -13,6 +13,7 @@ use HomeCEU\DTS\UseCase\GetTemplateRequest;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Exception\NotFoundException;
 
 class GetTemplate {
   private $useCase;
@@ -40,7 +41,7 @@ class GetTemplate {
           ->getBody()
           ->write($template->body);
     } catch (RecordNotFoundException $e) {
-      return $response->withStatus(404);
+      throw new NotFoundException($request, $response);
     }
   }
 }

--- a/api/Template/ListDocTypes.php
+++ b/api/Template/ListDocTypes.php
@@ -24,25 +24,21 @@ class ListDocTypes {
   }
 
   public function __invoke(Request $request, Response $response, $args) {
-    try {
-      $docTypes = $this->useCase->getDocTypes();
-      $responseData = [
-          'total' => count($docTypes),
-          'items' => array_map(function ($row) {
-            return [
-                'docType' => $row['docType'],
-                'templateCount' => $row['templateCount'],
-                'links' => [
-                    'templates' => "/template?filter[type]={$row['docType']}"
-                ]
-            ];
-          }, $docTypes)
-      ];
-      return $response
-          ->withStatus(200)
-          ->withJson($responseData);
-    } catch (Exception $e) {
-      return $response->withStatus(500, __CLASS__." failure");
-    }
+    $docTypes = $this->useCase->getDocTypes();
+    $responseData = [
+        'total' => count($docTypes),
+        'items' => array_map(function ($row) {
+          return [
+              'docType' => $row['docType'],
+              'templateCount' => $row['templateCount'],
+              'links' => [
+                  'templates' => "/template?filter[type]={$row['docType']}"
+              ]
+          ];
+        }, $docTypes)
+    ];
+    return $response
+        ->withStatus(200)
+        ->withJson($responseData);
   }
 }

--- a/api/Template/ListTemplates.php
+++ b/api/Template/ListTemplates.php
@@ -31,23 +31,19 @@ class ListTemplates {
   }
 
   public function __invoke(Request $request, Response $response, $args) {
-    try {
-      $queryParams = $request->getQueryParams();
-      $filter = empty($queryParams['filter']) ? [] : $queryParams['filter'];
-      $templates = $this->getTemplates($filter);
+    $queryParams = $request->getQueryParams();
+    $filter = empty($queryParams['filter']) ? [] : $queryParams['filter'];
+    $templates = $this->getTemplates($filter);
 
-      $responseData = [
-          'total' => count($templates),
-          'items' => array_map(function (Template $t) {
-            return ResponseHelper::templateDetailModel($t);
-          },$templates)
-      ];
-      return $response
-          ->withStatus(200)
-          ->withJson($responseData);
-    } catch (Exception $e) {
-      return $response->withStatus(500, __CLASS__." failure");
-    }
+    $responseData = [
+        'total' => count($templates),
+        'items' => array_map(function (Template $t) {
+          return ResponseHelper::templateDetailModel($t);
+        },$templates)
+    ];
+    return $response
+        ->withStatus(200)
+        ->withJson($responseData);
   }
 
   protected function getTemplates($filter=[]) {

--- a/api/Template/ListVersions.php
+++ b/api/Template/ListVersions.php
@@ -29,19 +29,15 @@ class ListVersions {
   }
 
   public function __invoke(Request $request, Response $response, $args) {
-    try {
-      $templates = $this->useCase->getVersions($args['docType'], $args['templateKey']);
-      $responseData = [
-          'total' => count($templates),
-          'items' => array_map(function (Template $t) {
-            return ResponseHelper::templateDetailModel($t);
-          },$templates)
-      ];
-      return $response
-          ->withStatus(200)
-          ->withJson($responseData);
-    } catch (Exception $e) {
-      return $response->withStatus(500, __CLASS__." failure");
-    }
+    $templates = $this->useCase->getVersions($args['docType'], $args['templateKey']);
+    $responseData = [
+        'total' => count($templates),
+        'items' => array_map(function (Template $t) {
+          return ResponseHelper::templateDetailModel($t);
+        },$templates)
+    ];
+    return $response
+        ->withStatus(200)
+        ->withJson($responseData);
   }
 }

--- a/api/services.php
+++ b/api/services.php
@@ -4,8 +4,6 @@ namespace HomeCEU\DTS\Api;
 
 use HomeCEU\DTS\Db;
 use HomeCEU\DTS\Db\Config;
-use HomeCEU\DTS\Render\TemplateCompiler;
-use HomeCEU\DTS\Render\TemplateHelpers;
 
 // this array gets passed into Slim\Container
 return [
@@ -18,13 +16,13 @@ return [
     'dbConnection' => function($container) {
       return Db::connection();
     },
-    'templateCompiler' => function($container) {
-      $compiler = TemplateCompiler::create();
-      $compiler->addHelper(TemplateHelpers::ifComparisonHelper());
-
-      return $compiler;
-    },
     'logger' => function($container) {
       return Logger::instance();
+    },
+    'errorHandler' => function ($c) {
+      return new ErrorHandler($c);
+    },
+    'phpErrorHandler' => function ($c) {
+      return new ErrorHandler($c);
     }
 ];

--- a/api/services.php
+++ b/api/services.php
@@ -1,21 +1,30 @@
 <?php
 
-// this array gets passed into Slim\Container
+namespace HomeCEU\DTS\Api;
 
+use HomeCEU\DTS\Db;
+use HomeCEU\DTS\Db\Config;
+use HomeCEU\DTS\Render\TemplateCompiler;
+use HomeCEU\DTS\Render\TemplateHelpers;
+
+// this array gets passed into Slim\Container
 return [
     'settings' => [
         'addContentLengthHeader' => false,
     ],
     'dbConfig' => function ($container) {
-      return \HomeCEU\DTS\Db\Config::fromEnv();
+      return Config::fromEnv();
     },
     'dbConnection' => function($container) {
-      return \HomeCEU\DTS\Db::connection();
+      return Db::connection();
     },
     'templateCompiler' => function($container) {
-      $compiler = \HomeCEU\DTS\Render\TemplateCompiler::create();
-      $compiler->addHelper(\HomeCEU\DTS\Render\TemplateHelpers::ifComparisonHelper());
+      $compiler = TemplateCompiler::create();
+      $compiler->addHelper(TemplateHelpers::ifComparisonHelper());
 
       return $compiler;
+    },
+    'logger' => function($container) {
+      return Logger::instance();
     }
 ];

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "robmorgan/phinx": "^0.11.4",
         "nette/database": "^3.0",
         "zordius/lightncandy": "^1.2",
-        "mikehaertl/phpwkhtmltopdf": "^2.4"
+        "mikehaertl/phpwkhtmltopdf": "^2.4",
+        "monolog/monolog": "^2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5fc9561bdc9ed2b19d3a0f14ff2e033c",
+    "content-hash": "c6af0441bf42ff86a80b9e816c2fdb3c",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -468,6 +468,87 @@
                 "wkhtmltopdf"
             ],
             "time": "2019-08-17T07:53:19+00:00"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "f9eee5cec93dfb313a38b6b288741e84e53f02d5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f9eee5cec93dfb313a38b6b288741e84e53f02d5",
+                "reference": "f9eee5cec93dfb313a38b6b288741e84e53f02d5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "psr/log": "^1.0.1"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^6.0",
+                "graylog2/gelf-php": "^1.4.2",
+                "php-amqplib/php-amqplib": "~2.4",
+                "php-console/php-console": "^3.1.3",
+                "php-parallel-lint/php-parallel-lint": "^1.0",
+                "phpspec/prophecy": "^1.6.1",
+                "phpunit/phpunit": "^8.5",
+                "predis/predis": "^1.1",
+                "rollbar/rollbar": "^1.3",
+                "ruflin/elastica": ">=0.90 <3.0",
+                "swiftmailer/swiftmailer": "^5.3|^6.0"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "php-console/php-console": "Allow sending log messages to Google Chrome",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "http://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "time": "2020-07-23T08:41:23+00:00"
         },
         {
             "name": "nette/caching",
@@ -2766,6 +2847,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2019-09-17T06:23:10+00:00"
         },
         {

--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -3,3 +3,5 @@
 ini_set('error_reporting', E_ALL);
 ini_set('display_errors', '1');
 ini_set('display_startup_errors', '1');
+
+require_once(__DIR__.'/vendor/autoload.php');

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" verbose="true" bootstrap="./vendor/autoload.php">
+<phpunit colors="true" verbose="true" bootstrap="./phpunit-bootstrap.php">
     <php>
         <includePath>./src</includePath>
         <includePath>./api</includePath>

--- a/tests/Api/TestCase.php
+++ b/tests/Api/TestCase.php
@@ -182,6 +182,15 @@ class TestCase extends \HomeCEU\Tests\TestCase {
   }
 
   protected function assertStatus(int $code, ResponseInterface $response): void {
-    Assert::assertEquals($code, $response->getStatusCode(), sprintf("Status %s does not match %s", $response->getStatusCode(), $code));
+    Assert::assertEquals(
+        $code,
+        $response->getStatusCode(),
+        sprintf(
+            "Status %s does not match %s\n Reason: %s",
+            $response->getStatusCode(),
+            $code,
+            $response->getReasonPhrase()
+        )
+    );
   }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,6 +15,7 @@ class TestCase extends \PHPUnit\Framework\TestCase {
     if (!defined('APP_ROOT')) {
       define('APP_ROOT', self::$APP_ROOT);
     }
+    putenv("APP_LOG_DIR=/var/log/app/tests");
   }
 
   public static function faker() {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,10 +6,14 @@ use HomeCEU\DTS\Entity\DocData;
 use HomeCEU\DTS\Entity\Template;
 
 class TestCase extends \PHPUnit\Framework\TestCase {
+
+  protected static $APP_ROOT;
+
   public static function setUpBeforeClass(): void {
     parent::setUpBeforeClass();
+    self::$APP_ROOT = realpath(__DIR__.'/../');
     if (!defined('APP_ROOT')) {
-      define('APP_ROOT', realpath(__DIR__.'/../'));
+      define('APP_ROOT', self::$APP_ROOT);
     }
   }
 


### PR DESCRIPTION
- if app env is dev, report all errors, including notices.
- added monolog to diContainer as logger
- add monolog to log errors, seperating errors from running tests to errors when hitting the api
- remove api catch of \Exception as new error handler middleware will catch it for all, also using slim to handle 404's which is much nicer